### PR TITLE
Use click for CLI and implement the -c argument

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sly
+click

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
   classifiers=classifiers,
   keywords='swas,language,swas lang', 
   packages=find_packages(),
-  install_requires= ['sly'],
+  install_requires= ['sly', 'click'],
   python_requires='>=3.6'
 )

--- a/swas/__main__.py
+++ b/swas/__main__.py
@@ -1,13 +1,24 @@
-from sys import argv
+import click
+
 from .executor import execute, shell
 
-def main():
-    
-    if len(argv) <= 1:
-        shell()
-    else:
-        fp = argv[1]
-        execute(fp)
+@click.command()
+@click.option('-c', '--code')
+@click.argument(
+    'src',
+    type=click.Path(exists=True, dir_okay=False),
+    required=False
+)
+def main(src, code):
+    if code is None:
+        if src is None:
+            shell()
+            return
+        else:
+            with open(src) as f:
+                code = f.read()
+
+    execute(code)
 
 if __name__ == '__main__':
     main()

--- a/swas/executor.py
+++ b/swas/executor.py
@@ -190,10 +190,7 @@ def evaluate(tree):
 class Break:
     pass
 
-def execute(fp):
-    with open(fp, "r") as f:
-        text = f.read()
-
+def execute(text):
     lexer = SwasLexer()
     parser = SwasParser()
     tree = parser.parse(lexer.tokenize(text))


### PR DESCRIPTION
[`click`](https://click.palletsprojects.com/en/8.0.x/) is a cool package that makes CLI commands easy. This PR uses click for commands and adds the `-c` argument.

Usage:
```
$ python -m swas
Swas 1.8.3
swas > output "Hello, World!"
Hello, World!

$ python -m swas test.swas
Hello, World!

$ python -m swas -c "output 'Hello, World!'"
Hello, World!
```